### PR TITLE
Adds logging to script

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,3 +16,5 @@ categories = ["command-line-utilities", "filesystem"]
 [dependencies]
 zip = "0.5"
 clap = "2.33.3"
+simplelog = "^0.10.0"
+log = "0.4.14"

--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ moss-fmt [FLAGS] [OPTIONS] --dir <dir> --filename <file>
   `__MACOSX` and `node_modules`.
 - `-o`, `--output`: Directory to store resulting files. Defaults to current
   working directory.
+- `-l`, `--log-file`: File to store run information like zips without a file or
+  files that are compressed using unsupported methods. Defaults to `moss-fmt.log`
 
 
 ## Features

--- a/src/path_verifier.rs
+++ b/src/path_verifier.rs
@@ -1,19 +1,19 @@
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::path::Path;
 
 /// Struct that verifies [`Path`] objects against provided arguments
 ///
-/// Holds a [`HashSet`] of folders to exclude and a [`HashSet`] of files the user is searching for.
+/// Holds a [`HashSet`] of folders to exclude and a [`HashMap`] of files the user is searching for.
 #[derive(Debug)]
 pub struct PathVerifier {
     restricted_folders: HashSet<String>,
-    search_files: HashSet<String>,
+    search_files: HashMap<String, bool>,
 }
 
 impl PathVerifier {
     /// Add a new file name to search for
     pub fn add_search_file(&mut self, file_name: &str) -> Self {
-        self.search_files.insert(file_name.to_string());
+        self.search_files.insert(file_name.to_string(), false);
         Self {
             restricted_folders: self.restricted_folders.clone(),
             search_files: self.search_files.clone(),
@@ -41,15 +41,38 @@ impl PathVerifier {
     ///
     /// // The path contains "__MACOSX" which is excluded by default
     /// let file_path = Path::new("__MACOSX/index.js");
-    /// let verifier = PathVerifier::default().add_search_file("index.js");
+    /// let mut verifier = PathVerifier::default().add_search_file("index.js");
     /// assert!(!verifier.verify(file_path));
     /// ```
-    pub fn verify(&self, path: &Path) -> bool {
+    pub fn verify(&mut self, path: &Path) -> bool {
         let mut pieces = path.components().map(|comp| comp.as_os_str());
-        pieces.all(|comp| !self.restricted_folders.contains(comp.to_str().unwrap()))
-            && self
-                .search_files
-                .contains(path.file_name().unwrap().to_str().unwrap())
+        let file_name = path.file_name().unwrap().to_str().unwrap().to_string();
+        if *self.search_files.get(&file_name).unwrap_or(&true) {
+            return false;
+        }
+        let valid = pieces.all(|comp| !self.restricted_folders.contains(comp.to_str().unwrap()))
+            && self.search_files.contains_key(&file_name);
+        self.search_files.insert(file_name, valid);
+        return valid;
+    }
+
+    /// Resets the progress of a PathVerifier
+    pub fn reset(&mut self) -> () {
+        for key in self.search_files.clone().keys() {
+            self.search_files.insert(key.to_string(), false);
+        }
+    }
+
+    pub fn print_progress(&self, folder_name: &String) -> () {
+        let not_found = self
+            .search_files
+            .clone()
+            .into_iter()
+            .filter_map(|(k, v)| if v { None } else { Some(k) })
+            .collect::<Vec<String>>();
+        for name in not_found {
+          error!("{} was not found in {}", name, folder_name);
+        }
     }
 }
 
@@ -60,7 +83,7 @@ impl Default for PathVerifier {
                 .iter()
                 .cloned()
                 .collect(),
-            search_files: HashSet::new(),
+            search_files: HashMap::new(),
         }
     }
 }
@@ -72,42 +95,42 @@ mod tests {
     #[test]
     fn path_verifier_denies_when_file_in_restricted() {
         let file_path = Path::new("__MACOSX/index.js");
-        let verifier = PathVerifier::default().add_search_file("index.js");
+        let mut verifier = PathVerifier::default().add_search_file("index.js");
         assert!(!verifier.verify(file_path));
     }
 
     #[test]
     fn path_verifier_accepts_file_nested() {
         let file_path = Path::new("foo/bar/index.js");
-        let verifier = PathVerifier::default().add_search_file("index.js");
+        let mut verifier = PathVerifier::default().add_search_file("index.js");
         assert!(verifier.verify(file_path));
     }
 
     #[test]
     fn path_verifier_accepts_file_bare() {
         let file_path = Path::new("index.js");
-        let verifier = PathVerifier::default().add_search_file("index.js");
+        let mut verifier = PathVerifier::default().add_search_file("index.js");
         assert!(verifier.verify(file_path));
     }
 
     #[test]
     fn path_verifier_denies_folder_named_search() {
         let file_path = Path::new("foo/bar/index.js/incorrect.js");
-        let verifier = PathVerifier::default().add_search_file("index.js");
+        let mut verifier = PathVerifier::default().add_search_file("index.js");
         assert!(!verifier.verify(file_path));
     }
 
     #[test]
     fn path_verifier_denies_file_nested() {
         let file_path = Path::new("foo/bar/baz.js");
-        let verifier = PathVerifier::default().add_search_file("index.js");
+        let mut verifier = PathVerifier::default().add_search_file("index.js");
         assert!(!verifier.verify(file_path));
     }
 
     #[test]
     fn path_verifier_denies_file_bare() {
         let file_path = Path::new("baz.js");
-        let verifier = PathVerifier::default().add_search_file("index.js");
+        let mut verifier = PathVerifier::default().add_search_file("index.js");
         assert!(!verifier.verify(file_path));
     }
 }


### PR DESCRIPTION
- `PathVerifier` now holds internal state about what files have been seen. This requires `reset` to be called after a zip is processed, but allows checking what files were not seen in a zip but were being searched for.
- Integrates a much more elegant form of verbosity in `log` and `simplelog`, with the new `--log-file` option.
- Handles zip files in alphabetical order for cleaner logging information.